### PR TITLE
Refactor: Separate inline CSS and JS from docs/index.html

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4,59 +4,7 @@
   <meta charset="UTF-8">
   <title>Email Form</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <style>
-    html, body {
-      height: 100%;
-      margin: 0;
-      padding: 0;
-    }
-    body {
-      min-height: 100vh;
-      background: #db2a44;
-      display: flex;
-      flex-direction: column;
-      justify-content: center;
-      align-items: center;
-      font-family: Arial, sans-serif;
-    }
-    .container {
-      width: 100%;
-      max-width: 350px;
-      display: flex;
-      flex-direction: column;
-      gap: 1.5rem;
-      align-items: stretch;
-    }
-    .logo {
-      width: 100%;
-      text-align: center;
-      margin-bottom: 0.5rem;
-    }
-    .logo img {
-      max-width: 200px; /* Increased from 120px */
-      height: auto;
-    }
-    input[type="text"], input[type="email"] {
-      padding: 0.75rem;
-      border: none;
-      border-radius: 4px;
-      font-size: 1rem;
-    }
-    button[type="submit"] {
-      padding: 0.75rem;
-      background: #193147;
-      color: #fff;
-      border: none;
-      border-radius: 4px;
-      font-size: 1rem;
-      font-weight: bold;
-      cursor: pointer;
-      transition: background 0.2s;
-    }
-    button[type="submit"]:hover {
-      background: #2a4066;
-    }
-  </style>
+  <link rel="stylesheet" href="style.css">
 </head>
 <body>
   <form class="container" id="emailForm">
@@ -69,78 +17,7 @@
     <input type="email" name="email" placeholder="Email" required>
     <button type="submit">Submit</button>
   </form>
-  <script>
-    document.getElementById('emailForm').addEventListener('submit', function(e) {
-      e.preventDefault();
-      const firstName = this.elements['firstName'].value;
-      const lastName = this.elements['lastName'].value;
-      const email = this.elements['email'].value;
-
-      // Get existing entries or initialize array
-      let entries = [];
-      try {
-        entries = JSON.parse(localStorage.getItem('entries')) || [];
-      } catch (e) {
-        entries = [];
-      }
-      entries.push({ firstName, lastName, email });
-      localStorage.setItem('entries', JSON.stringify(entries));
-
-      // Clear the form and refocus the first name field
-      this.reset();
-      this.elements['firstName'].focus();
-    });
-
-    // Download CSV logic
-    function downloadCSV() {
-      let entries = [];
-      try {
-        entries = JSON.parse(localStorage.getItem('entries')) || [];
-      } catch (e) {
-        entries = [];
-      }
-      if (entries.length === 0) {
-        alert('No entries to download.');
-        return;
-      }
-      const header = ['First Name', 'Last Name', 'Email'];
-      const rows = entries.map(e => [e.firstName, e.lastName, e.email]);
-      const csvContent = [header, ...rows]
-        .map(row => row.map(field => `"${(field || '').replace(/"/g, '""')}"`).join(','))
-        .join('\r\n');
-      const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.setAttribute('href', url);
-      a.setAttribute('download', 'entries.csv');
-      a.style.visibility = 'hidden';
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-    }
-  </script>
-  <a 
-    href="#" 
-    onclick="downloadCSV(); return false;" 
-    style="
-      position: fixed;
-      bottom: 20px;
-      right: 24px;
-      background: rgba(25,49,71,0.95);
-      color: #fff;
-      padding: 6px 16px;
-      border-radius: 16px;
-      font-size: 0.95rem;
-      text-decoration: none;
-      font-family: Arial, sans-serif;
-      box-shadow: 0 2px 8px rgba(0,0,0,0.10);
-      z-index: 1000;
-      opacity: 0.85;
-      transition: opacity 0.2s;
-    "
-    onmouseover="this.style.opacity='1'"
-    onmouseout="this.style.opacity='0.85'"
-    title="Download CSV"
-  >csv</a>
+  <a href="#" id="download-csv-link" title="Download CSV">csv</a>
+  <script src="script.js"></script>
 </body>
 </html>

--- a/docs/script.js
+++ b/docs/script.js
@@ -1,0 +1,68 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const emailForm = document.getElementById('emailForm');
+  const downloadLink = document.getElementById('download-csv-link');
+
+  if (emailForm) {
+    emailForm.addEventListener('submit', function(e) {
+      e.preventDefault();
+      const firstNameInput = this.elements['firstName'];
+      const lastNameInput = this.elements['lastName'];
+      const emailInput = this.elements['email'];
+
+      const firstName = firstNameInput.value;
+      const lastName = lastNameInput.value;
+      const email = emailInput.value;
+
+      // Get existing entries or initialize array
+      let entries = [];
+      try {
+        entries = JSON.parse(localStorage.getItem('entries')) || [];
+      } catch (error) { // Changed 'e' to 'error' for clarity
+        console.error('Error parsing localStorage entries:', error); // Added a console log for the error
+        entries = [];
+      }
+      entries.push({ firstName, lastName, email });
+      localStorage.setItem('entries', JSON.stringify(entries));
+
+      // Clear the form and refocus the first name field
+      this.reset();
+      firstNameInput.focus();
+    });
+  }
+
+  if (downloadLink) {
+    downloadLink.addEventListener('click', (event) => {
+      event.preventDefault();
+      downloadCSV();
+    });
+  }
+});
+
+// Download CSV logic
+function downloadCSV() {
+  let entries = [];
+  try {
+    entries = JSON.parse(localStorage.getItem('entries')) || [];
+  } catch (error) {
+    console.error('Error parsing localStorage entries for CSV download:', error);
+    entries = [];
+  }
+  if (entries.length === 0) {
+    alert('No entries to download.');
+    return;
+  }
+  const header = ['First Name', 'Last Name', 'Email'];
+  const rows = entries.map(e => [e.firstName, e.lastName, e.email]);
+  const csvContent = [header, ...rows]
+    .map(row => row.map(field => `"${(field || '').replace(/"/g, '""')}"`).join(','))
+    .join('\r\n');
+  const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.setAttribute('href', url);
+  a.setAttribute('download', 'entries.csv');
+  a.style.visibility = 'hidden';
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+}

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,0 +1,70 @@
+html, body {
+  height: 100%;
+  margin: 0;
+  padding: 0;
+}
+body {
+  min-height: 100vh;
+  background: #db2a44;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  font-family: Arial, sans-serif;
+}
+.container {
+  width: 100%;
+  max-width: 350px;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  align-items: stretch;
+}
+.logo {
+  width: 100%;
+  text-align: center;
+  margin-bottom: 0.5rem;
+}
+.logo img {
+  max-width: 200px; /* Increased from 120px */
+  height: auto;
+}
+input[type="text"], input[type="email"] {
+  padding: 0.75rem;
+  border: none;
+  border-radius: 4px;
+  font-size: 1rem;
+}
+button[type="submit"] {
+  padding: 0.75rem;
+  background: #193147;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  font-size: 1rem;
+  font-weight: bold;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+button[type="submit"]:hover {
+  background: #2a4066;
+}
+#download-csv-link {
+  position: fixed;
+  bottom: 20px;
+  right: 24px;
+  background: rgba(25,49,71,0.95);
+  color: #fff;
+  padding: 6px 16px;
+  border-radius: 16px;
+  font-size: 0.95rem;
+  text-decoration: none;
+  font-family: Arial, sans-serif;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.10);
+  z-index: 1000;
+  opacity: 0.85;
+  transition: opacity 0.2s;
+}
+#download-csv-link:hover {
+  opacity: 1;
+}


### PR DESCRIPTION
- Extracted inline CSS from `docs/index.html` into `docs/style.css`.
- Extracted inline JavaScript from `docs/index.html` into `docs/script.js`.
- Updated `docs/index.html` to link to the new external files.
- Moved inline styles for the CSV download link to `docs/style.css`.
- Refactored CSV download link event handlers:
    - `onclick` behavior moved to `docs/script.js`.
    - `onmouseover`/`onmouseout` behavior replaced with CSS hover effects.
- Cleaned up `docs/index.html`, `docs/style.css`, and `docs/script.js` for better readability, consistent formatting, and adherence to best practices.
- Added minor error logging for localStorage access in `docs/script.js`.