### PR TITLE
feat: Implement PWA for offline access to index.html

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>Email Form</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="manifest" href="manifest.json">
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
@@ -18,5 +19,18 @@
     <button type="submit">Submit</button>
   </form>
   <script src="script.js"></script>
+  <script>
+    if ('serviceWorker' in navigator) {
+      window.addEventListener('load', () => {
+        navigator.serviceWorker.register('/email-form/sw.js')
+          .then(registration => {
+            console.log('ServiceWorker registration successful with scope: ', registration.scope);
+          })
+          .catch(error => {
+            console.log('ServiceWorker registration failed: ', error);
+          });
+      });
+    }
+  </script>
 </body>
 </html>

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1,0 +1,20 @@
+{
+  "name": "Email Form",
+  "short_name": "EmailForm",
+  "icons": [
+    {
+      "src": "form-192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "form-512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ],
+  "start_url": "/email-form/index.html",
+  "display": "standalone",
+  "background_color": "#db2a44",
+  "theme_color": "#db2a44"
+}

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -1,0 +1,65 @@
+const CACHE_NAME = 'email-form-cache-v1';
+const urlsToCache = [
+  '/email-form/index.html',
+  '/email-form/style.css',
+  '/email-form/script.js',
+  '/email-form/ahep-logo.svg',
+  '/email-form/form-192.png',
+  '/email-form/form-512.png',
+  '/email-form/manifest.json'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME)
+      .then(cache => {
+        console.log('Opened cache');
+        return cache.addAll(urlsToCache);
+      })
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.open(CACHE_NAME).then(cache => {
+      return fetch(event.request).then(response => {
+        // If the request is successful, update the cache
+        if (response && response.status === 200) {
+          cache.put(event.request, response.clone());
+        }
+        return response;
+      }).catch(() => {
+        // If the network request fails, try to serve from cache
+        return cache.match(event.request).then(cachedResponse => {
+          if (cachedResponse) {
+            return cachedResponse;
+          }
+          // If not in cache either, and it's a navigation request for index.html,
+          // return the cached index.html as a fallback.
+          // This ensures the main page loads even if other specific assets weren't explicitly cached
+          // or if the exact request path doesn't match a cached entry but the app shell is needed.
+          if (event.request.mode === 'navigate' && event.request.url.endsWith('/')) {
+            return cache.match('/email-form/index.html');
+          }
+          // For other types of requests or if index.html is not found,
+          // it will result in a standard browser error page for offline.
+        });
+      });
+    })
+  );
+});
+
+self.addEventListener('activate', event => {
+  const cacheWhitelist = [CACHE_NAME];
+  event.waitUntil(
+    caches.keys().then(cacheNames => {
+      return Promise.all(
+        cacheNames.map(cacheName => {
+          if (cacheWhitelist.indexOf(cacheName) === -1) {
+            return caches.delete(cacheName);
+          }
+        })
+      );
+    })
+  );
+});


### PR DESCRIPTION
Adds a manifest.json and a service worker (sw.js) to enable Progressive Web App capabilities for the email form page (index.html).

Key changes:
- Created `docs/manifest.json` with app metadata, icons, start URL, and theme colors. Assumed icon files `form-192.png` and `form-512.png` are present in `docs/`.
- Created `docs/sw.js` implementing a network-first caching strategy. This allows the app to work offline using cached assets and ensures that you get the latest version when online. Cached assets include HTML, CSS, JS, SVG logo, and icon files.
- Modified `docs/index.html` to link to `manifest.json` and register the service worker. The service worker is registered with the scope `/email-form/` to align with the GitHub Pages hosting structure.

The `admin.html` page is intentionally excluded from the PWA caching and offline capabilities.