### PR TITLE
Fix: Change form submission focus to email field

### DIFF
--- a/docs/script.js
+++ b/docs/script.js
@@ -25,7 +25,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
       // Clear the form and refocus the first name field
       this.reset();
-      firstNameInput.focus();
+      emailInput.focus();
     });
   }
 });


### PR DESCRIPTION
After form submission, the cursor was previously resetting to the first name field. This commit modifies the JavaScript to focus on the email address field instead, improving your experience.