### PR TITLE
Refactor: Improve admin page table UX and add pagination

### DIFF
--- a/docs/admin.html
+++ b/docs/admin.html
@@ -10,12 +10,11 @@
   <div class="container"> <!-- Using existing container class for some basic centering/width restriction -->
     <h1 id="heading">Stored Entries</h1>
     
-    <button type="button" id="download-all-csv">Download All as CSV</button>
-    
-    <table id="entries-table">
-      <thead>
-        <tr>
-          <th>First Name</th>
+    <div class="table-wrapper"> <!-- Added table wrapper -->
+      <table id="entries-table">
+        <thead>
+          <tr>
+            <th>First Name</th>
           <th>Last Name</th>
           <th>Email</th>
           <th>Action</th>
@@ -25,7 +24,13 @@
         <!-- Entries will be populated here by JavaScript -->
       </tbody>
     </table>
+    </div> <!-- Closed table wrapper -->
+
+    <div id="pagination-controls" class="pagination-controls">
+      <!-- Pagination controls will be inserted here by JavaScript -->
+    </div>
     
+    <button type="button" id="download-all-csv">Download All as CSV</button>
     <button type="button" id="delete-all-entries">Delete All Entries</button>
   </div>
 

--- a/docs/admin.js
+++ b/docs/admin.js
@@ -2,6 +2,10 @@ document.addEventListener('DOMContentLoaded', function() {
   const tableBody = document.querySelector('#entries-table tbody');
   const pageTitle = document.querySelector('#heading');
 
+  let allEntries = [];
+  let currentPage = 1;
+  let entriesPerPage = 20; // Default value, will be configurable
+
   function getStoredEntries() {
     let entries = [];
     try {
@@ -21,71 +25,184 @@ document.addEventListener('DOMContentLoaded', function() {
     }
   }
 
-  function deleteEntry(index) {
-    console.log('Attempting to delete entry at index:', index); // For debugging
-    let entries = getStoredEntries();
-    if (index >= 0 && index < entries.length) {
-      entries.splice(index, 1);
-      saveEntries(entries);
-      loadEntries(); // Refresh the table
+  function deleteEntry(originalIndex) {
+    console.log('Attempting to delete entry at original index:', originalIndex); // For debugging
+    if (originalIndex >= 0 && originalIndex < allEntries.length) {
+      allEntries.splice(originalIndex, 1);
+      saveEntries(allEntries);
+      // Recalculate total pages and adjust currentPage if it's now out of bounds
+      const totalPages = entriesPerPage === 0 ? 1 : Math.ceil(allEntries.length / entriesPerPage);
+      if (currentPage > totalPages && totalPages > 0) {
+        currentPage = totalPages;
+      } else if (allEntries.length === 0) {
+        currentPage = 1; // Reset to page 1 if no entries left
+      }
+      loadEntries(); // Reload all entries and refresh display
     } else {
-      console.error('Invalid index for deletion:', index);
+      console.error('Invalid original index for deletion:', originalIndex);
     }
   }
 
   function updateTitleWithCount(count) {
     if (pageTitle) {
-      pageTitle.textContent = `${count} Entries`;
+      pageTitle.textContent = `${count} Stored Entries`; // Kept original wording
     }
   }
 
-  function loadEntries() {
-    const entries = getStoredEntries();
-    // Clear existing table rows
-    tableBody.innerHTML = ''; 
+  function displayPage() {
+    tableBody.innerHTML = ''; // Clear existing table rows
 
-    // Update the title with the count
-    updateTitleWithCount(entries.length);
-
-    if (entries.length === 0) {
+    if (allEntries.length === 0) {
       const row = tableBody.insertRow();
       const cell = row.insertCell();
-      cell.setAttribute('colspan', '4'); // Span across all 4 columns
+      cell.setAttribute('colspan', '4');
       cell.textContent = 'No entries found.';
-      cell.style.textAlign = 'center'; // Basic styling for the message
-    } else {
-      entries.forEach((entry, index) => {
-        const row = tableBody.insertRow();
-        
-        const firstNameCell = row.insertCell();
-        firstNameCell.textContent = entry.firstName || '';
-        
-        const lastNameCell = row.insertCell();
-        lastNameCell.textContent = entry.lastName || '';
-        
-        const emailCell = row.insertCell();
-        emailCell.textContent = entry.email || '';
-        
-        const actionCell = row.insertCell();
-        const deleteButton = document.createElement('button');
-        deleteButton.textContent = 'Delete';
-        deleteButton.onclick = function() { // Using onclick for simplicity here
-          deleteEntry(index);
-        };
-        actionCell.appendChild(deleteButton);
-      });
+      cell.style.textAlign = 'center';
+      return; // Exit early
     }
+
+    let entriesToDisplay = [];
+    if (entriesPerPage === 0) { // "All" selected
+      entriesToDisplay = allEntries;
+    } else {
+      const startIndex = (currentPage - 1) * entriesPerPage;
+      const endIndex = startIndex + entriesPerPage;
+      entriesToDisplay = allEntries.slice(startIndex, endIndex);
+    }
+
+    entriesToDisplay.forEach((entry, indexOnPage) => {
+      const originalIndex = (entriesPerPage === 0) ? indexOnPage : (currentPage - 1) * entriesPerPage + indexOnPage;
+      const row = tableBody.insertRow();
+
+      const firstNameCell = row.insertCell();
+      firstNameCell.textContent = entry.firstName || '';
+
+      const lastNameCell = row.insertCell();
+      lastNameCell.textContent = entry.lastName || '';
+
+      const emailCell = row.insertCell();
+      emailCell.textContent = entry.email || '';
+
+      const actionCell = row.insertCell();
+      const deleteButton = document.createElement('button');
+      deleteButton.textContent = 'Delete';
+      deleteButton.onclick = function() {
+        // Pass the original index from the allEntries array
+        deleteEntry(originalIndex);
+      };
+      actionCell.appendChild(deleteButton);
+    });
+  }
+
+  function loadEntries() {
+    allEntries = getStoredEntries();
+    updateTitleWithCount(allEntries.length); // Update title with total count
+
+    // Reset current page if it's out of bounds (e.g., after deleting all items on the last page)
+    const totalPages = entriesPerPage === 0 ? 1 : Math.ceil(allEntries.length / entriesPerPage);
+    if (currentPage > totalPages && totalPages > 0) {
+        currentPage = totalPages;
+    } else if (allEntries.length === 0) {
+        currentPage = 1; // Default to page 1 if no entries
+    }
+
+    displayPage(); // Display the current page
+    setupPaginationControls(); // Setup or update pagination controls
+  }
+
+  function setupPaginationControls() {
+    const controlsContainer = document.getElementById('pagination-controls');
+    if (!controlsContainer) return;
+    controlsContainer.innerHTML = ''; // Clear existing controls
+
+    if (allEntries.length === 0 && entriesPerPage !== 0) { // Don't show controls if no entries unless "All" is selected (which might show "0 entries")
+        // Optionally, hide controls container or show a specific message if no entries.
+        // For now, if allEntries is empty, displayPage shows "No entries found", and controls will be minimal or not shown.
+        // If entriesPerPage is 0 (All), we might still want to show the selector.
+    }
+
+    const totalPages = entriesPerPage === 0 ? 1 : Math.ceil(allEntries.length / entriesPerPage);
+
+    // Entries per page selector
+    const perPageLabel = document.createElement('label');
+    perPageLabel.textContent = 'Rows per page: ';
+    perPageLabel.setAttribute('for', 'entries-per-page-select');
+
+    const perPageSelect = document.createElement('select');
+    perPageSelect.id = 'entries-per-page-select';
+    const options = [20, 50, 100, 0]; // 0 for "All"
+    const optionLabels = { 20: '20', 50: '50', 100: '100', 0: 'All' };
+
+    options.forEach(num => {
+      const option = document.createElement('option');
+      option.value = num;
+      option.textContent = optionLabels[num];
+      if (num === entriesPerPage) {
+        option.selected = true;
+      }
+      perPageSelect.appendChild(option);
+    });
+
+    perPageSelect.addEventListener('change', function(event) {
+      entriesPerPage = parseInt(event.target.value, 10);
+      currentPage = 1; // Reset to first page
+      loadEntries();
+    });
+
+    controlsContainer.appendChild(perPageLabel);
+    controlsContainer.appendChild(perPageSelect);
+
+    // Only show page navigation if not "All" and more than one page
+    if (entriesPerPage !== 0 && totalPages > 1) {
+      const pageInfo = document.createElement('span');
+      pageInfo.textContent = ` Page ${currentPage} of ${totalPages} `;
+      pageInfo.style.margin = '0 10px'; // Add some spacing
+
+      const prevButton = document.createElement('button');
+      prevButton.textContent = 'Previous';
+      prevButton.disabled = currentPage === 1;
+      prevButton.addEventListener('click', () => {
+        if (currentPage > 1) {
+          currentPage--;
+          loadEntries();
+        }
+      });
+
+      const nextButton = document.createElement('button');
+      nextButton.textContent = 'Next';
+      nextButton.disabled = currentPage === totalPages;
+      nextButton.addEventListener('click', () => {
+        if (currentPage < totalPages) {
+          currentPage++;
+          loadEntries();
+        }
+      });
+
+      controlsContainer.appendChild(prevButton);
+      controlsContainer.appendChild(pageInfo);
+      controlsContainer.appendChild(nextButton);
+    } else if (entriesPerPage === 0 && allEntries.length > 0) {
+      // Optionally show "Displaying all X entries" or similar if "All" is selected
+      const pageInfo = document.createElement('span');
+      pageInfo.textContent = ` Displaying all ${allEntries.length} entries. `;
+      pageInfo.style.margin = '0 10px';
+      controlsContainer.appendChild(pageInfo);
+    }
+     // If allEntries.length is 0, displayPage shows "No entries", and controls will just be the selector.
   }
 
   // Initial load of entries
   loadEntries();
 
   // Refresh table when the tab/window is refocused
+  // Consider if full reload or just re-render is needed. Full reload is simpler for now.
   window.addEventListener('focus', loadEntries);
 
   function downloadAllCSV() {
-    const entries = getStoredEntries(); // Use existing function
-    if (entries.length === 0) {
+    // This function should still use allEntries or getStoredEntries() directly
+    // as it's "Download ALL"
+    const entriesToDownload = getStoredEntries();
+    if (entriesToDownload.length === 0) {
       alert('No entries to download.');
       return;
     }

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,25 +1,40 @@
 html, body {
-  height: 100%;
   margin: 0;
   padding: 0;
+  font-family: Arial, sans-serif; /* Moved font-family here */
 }
 body {
   min-height: 100vh;
   background: #db2a44;
   display: flex;
   flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  font-family: Arial, sans-serif;
+  align-items: center; /* Center content horizontally */
+  padding-top: 2rem; /* Add some padding at the top */
+  padding-bottom: 2rem; /* Add some padding at the bottom */
+  box-sizing: border-box; /* Ensure padding doesn't add to height */
 }
 .container {
-  width: 100%;
-  max-width: 350px;
+  width: 90%; /* Use percentage for responsiveness */
+  max-width: 800px; /* Increased max-width for table content */
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
-  align-items: stretch;
+  align-items: stretch; /* Keep this for children like buttons */
+  background-color: #f0f0f0; /* Added a light background for the container */
+  padding: 1rem; /* Add some padding inside the container */
+  border-radius: 8px; /* Optional: rounded corners for the container */
+  box-shadow: 0 4px 8px rgba(0,0,0,0.1); /* Optional: add some shadow */
 }
+
+/* New wrapper for table scrolling */
+.table-wrapper {
+  max-height: 70vh; /* Set a max-height, e.g., 70% of viewport height */
+  overflow-y: auto; /* Add vertical scroll if content exceeds max-height */
+  width: 100%; /* Ensure it takes full width of its parent */
+  border: 1px solid #ddd; /* Optional: border around the scrollable area */
+  border-radius: 4px; /* Match table's border-radius */
+}
+
 .logo {
   width: 100%;
   text-align: center;
@@ -85,15 +100,16 @@ body > .container > h1 {
   cursor: pointer;
   font-size: 0.95rem;
   transition: background-color 0.2s, opacity 0.2s; /* Combined transitions */
+  /* Margins will be handled by the flex container's gap property */
 }
 
 #download-all-csv {
-  margin-bottom: 1rem;
+  /* margin-bottom: 1rem; */ /* Removed */
   background: #4CAF50; /* Green */
 }
 
 #delete-all-entries {
-  margin-top: 1rem;
+  /* margin-top: 1rem; */ /* Removed */
   background: #f44336; /* Red */
 }
 
@@ -114,4 +130,54 @@ body > .container > h1 {
 
 #entries-table button:hover {
   background-color: #d4d4d4;
+}
+
+/* Pagination Controls Styles */
+.pagination-controls {
+  display: flex;
+  justify-content: space-between; /* Align items with space between */
+  align-items: center;
+  padding: 0.75rem 0; /* Add some vertical padding */
+  flex-wrap: wrap; /* Allow wrapping on smaller screens */
+  gap: 0.5rem; /* Add gap between items if they wrap */
+}
+
+.pagination-controls label {
+  font-size: 0.9rem;
+  color: #333; /* Darker text for better readability on light .container background */
+}
+
+.pagination-controls select {
+  padding: 0.35rem 0.5rem;
+  border-radius: 4px;
+  border: 1px solid #ccc;
+  font-size: 0.9rem;
+  margin-right: 1rem; /* Space after the select */
+}
+
+.pagination-controls button {
+  padding: 0.35rem 0.75rem;
+  background-color: #5cb85c; /* A slightly different green */
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.9rem;
+  transition: background-color 0.2s;
+}
+
+.pagination-controls button:disabled {
+  background-color: #cccccc;
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
+.pagination-controls button:hover:not(:disabled) {
+  background-color: #4cae4c; /* Darker green on hover */
+}
+
+.pagination-controls span {
+  font-size: 0.9rem;
+  color: #333;
+  margin: 0 0.5rem; /* Spacing around page info */
 }


### PR DESCRIPTION
This commit addresses several UX issues on the admin entries page:

1.  **Fixes Table Overflow:**
    *   Adjusted body CSS to prevent the top of the page from being cut off when the table is tall.
    *   Wrapped the main table in a scrollable `div` (`.table-wrapper`) with a `max-height` to ensure the table itself scrolls independently if its content exceeds the viewport allowance.
    *   Increased the `max-width` of the main container for better table readability.

2.  **Moves "Download CSV" Button:**
    *   The "Download All as CSV" button is now positioned below the entries table and above the "Delete All Entries" button for a more logical flow.

3.  **Adds Pagination:**
    *   Implemented JavaScript logic for paginating table entries.
    *   Users can select the number of entries per page (20, 50, 100, or "All").
    *   "Previous" and "Next" buttons allow navigation through pages.
    *   The total number of entries is still displayed in the heading.
    *   Pagination controls are dynamically generated and styled.
    *   Deletion and CSV download functionalities correctly account for the full dataset, not just the paginated view.