### PR TITLE
feat: Add confirmation modal to form submission

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -19,6 +19,24 @@
     <button type="submit">Submit</button>
   </form>
   <script src="script.js"></script>
+
+  <!-- Modal Structure -->
+  <div id="confirmationModal" class="modal" style="display: none;">
+    <div class="modal-content">
+      <h2>Confirm Your Details</h2>
+      <div id="modalData">
+        <p><strong>Email:</strong> <span id="modalEmail"></span></p>
+        <p><strong>First Name:</strong> <span id="modalFirstName"></span></p>
+        <p><strong>Last Name:</strong> <span id="modalLastName"></span></p>
+      </div>
+      <div class="modal-buttons">
+        <button id="confirmBtn">Confirm</button>
+        <button id="editBtn">Edit</button>
+        <button id="clearBtn">Clear</button>
+      </div>
+    </div>
+  </div>
+
   <script>
     if ('serviceWorker' in navigator) {
       window.addEventListener('load', () => {

--- a/docs/script.js
+++ b/docs/script.js
@@ -1,5 +1,14 @@
 document.addEventListener('DOMContentLoaded', () => {
   const emailForm = document.getElementById('emailForm');
+  const modal = document.getElementById('confirmationModal');
+  const confirmBtn = document.getElementById('confirmBtn');
+  const editBtn = document.getElementById('editBtn');
+  const clearBtn = document.getElementById('clearBtn');
+  const modalEmail = document.getElementById('modalEmail');
+  const modalFirstName = document.getElementById('modalFirstName');
+  const modalLastName = document.getElementById('modalLastName');
+
+  let currentFormData = {};
 
   if (emailForm) {
     emailForm.addEventListener('submit', function(e) {
@@ -8,24 +17,77 @@ document.addEventListener('DOMContentLoaded', () => {
       const lastNameInput = this.elements['lastName'];
       const emailInput = this.elements['email'];
 
-      const firstName = firstNameInput.value;
-      const lastName = lastNameInput.value;
-      const email = emailInput.value;
+      currentFormData = {
+        firstName: firstNameInput.value,
+        lastName: lastNameInput.value,
+        email: emailInput.value,
+      };
 
-      // Get existing entries or initialize array
+      // Populate modal
+      modalEmail.textContent = currentFormData.email;
+      modalFirstName.textContent = currentFormData.firstName;
+      modalLastName.textContent = currentFormData.lastName;
+
+      // Show modal
+      modal.style.display = 'block';
+    });
+  }
+
+  if (modal) {
+    confirmBtn.addEventListener('click', () => {
+      // Save data to localStorage
       let entries = [];
       try {
         entries = JSON.parse(localStorage.getItem('entries')) || [];
-      } catch (error) { // Changed 'e' to 'error' for clarity
-        console.error('Error parsing localStorage entries:', error); // Added a console log for the error
+      } catch (error) {
+        console.error('Error parsing localStorage entries:', error);
         entries = [];
       }
-      entries.push({ firstName, lastName, email });
+      entries.push(currentFormData);
       localStorage.setItem('entries', JSON.stringify(entries));
 
-      // Clear the form and refocus the first name field
-      this.reset();
-      emailInput.focus();
+      // Clear the form
+      emailForm.reset();
+      // Hide modal
+      modal.style.display = 'none';
+      // Refocus the email field (assuming email is the first field typically)
+      if (emailForm.elements['email']) {
+        emailForm.elements['email'].focus();
+      }
+      currentFormData = {}; // Clear stored form data
+    });
+
+    editBtn.addEventListener('click', () => {
+      // Just hide the modal, form retains its values
+      modal.style.display = 'none';
+      // Optionally, focus the first field that had data or the first field in general
+      if (emailForm.elements['email']) {
+         emailForm.elements['email'].focus();
+      }
+    });
+
+    clearBtn.addEventListener('click', () => {
+      // Clear the form
+      emailForm.reset();
+      // Hide modal
+      modal.style.display = 'none';
+      // Refocus the email field
+      if (emailForm.elements['email']) {
+        emailForm.elements['email'].focus();
+      }
+      currentFormData = {}; // Clear stored form data
+    });
+
+    // Close modal if user clicks outside of the modal content (optional)
+    window.addEventListener('click', (event) => {
+      if (event.target === modal) {
+        modal.style.display = 'none';
+        // Decide if form should be reset or retain data.
+        // For now, let's assume "Edit" behavior (retain data)
+        if (emailForm.elements['email']) {
+           emailForm.elements['email'].focus();
+        }
+      }
     });
   }
 });

--- a/docs/style.css
+++ b/docs/style.css
@@ -180,3 +180,93 @@ body > .container > h1 {
   color: #333;
   margin: 0 0.5rem; /* Spacing around page info */
 }
+
+/* Modal Styles */
+.modal {
+  display: none; /* Hidden by default */
+  position: fixed; /* Stay in place */
+  z-index: 1000; /* Sit on top */
+  left: 0;
+  top: 0;
+  width: 100%; /* Full width */
+  height: 100%; /* Full height */
+  overflow: auto; /* Enable scroll if needed */
+  background-color: rgba(0,0,0,0.6); /* Black w/ opacity */
+  padding-top: 60px; /* Location of the box */
+}
+
+.modal-content {
+  background-color: #fefefe;
+  margin: 5% auto; /* 5% from the top and centered */
+  padding: 20px;
+  border: 1px solid #888;
+  width: 80%; /* Could be more or less, depending on screen size */
+  max-width: 500px; /* Maximum width */
+  border-radius: 8px;
+  box-shadow: 0 4px 8px rgba(0,0,0,0.2), 0 6px 20px rgba(0,0,0,0.19);
+  text-align: left;
+}
+
+.modal-content h2 {
+  text-align: center;
+  margin-top: 0;
+  margin-bottom: 15px; /* Added more space below heading */
+  color: #333;
+}
+
+#modalData p {
+  font-size: 1rem;
+  color: #333;
+  line-height: 1.6;
+  margin-bottom: 0.5rem;
+}
+
+#modalData p strong {
+  color: #193147; /* Using a theme color */
+}
+
+.modal-buttons {
+  display: flex;
+  justify-content: space-around; /* Distribute buttons evenly */
+  align-items: center; /* Vertically align items in case of wrapping or different heights */
+  margin-top: 25px; /* Slightly increased margin */
+  padding-top: 15px; /* Add some padding above the buttons */
+  border-top: 1px solid #eee; /* Separator line */
+  gap: 10px; /* Add gap between buttons */
+}
+
+.modal-buttons button {
+  padding: 10px 20px;
+  border: none;
+  border-radius: 4px;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: background-color 0.2s, opacity 0.2s;
+}
+
+#confirmBtn {
+  background-color: #4CAF50; /* Green */
+  color: white;
+}
+
+#confirmBtn:hover {
+  background-color: #45a049;
+}
+
+#editBtn {
+  background-color: #ffc107; /* Amber */
+  color: #333;
+}
+
+#editBtn:hover {
+  background-color: #e0a800;
+}
+
+#clearBtn {
+  background-color: #f44336; /* Red */
+  color: white;
+}
+
+#clearBtn:hover {
+  background-color: #da190b;
+}


### PR DESCRIPTION
Adds a confirmation step after the user clicks 'Submit' on the main form. A modal dialog displays the entered data (Email, First Name, Last Name) and provides three options:

- Confirm: Saves the data to localStorage, resets the form, and closes the modal.
- Edit: Closes the modal, allowing the user to modify the existing form data.
- Clear: Resets the form, closes the modal, and does not save the data.

The modal is also dismissable by clicking outside its content area, which defaults to the 'Edit' behavior.