### PR TITLE
Fix: Prevent body scroll on admin page

### DIFF
--- a/docs/admin.html
+++ b/docs/admin.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="admin-scroll-lock">
 <head>
   <meta charset="UTF-8">
   <title>Email Admin</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" href="style.css">
 </head>
-<body>
+<body class="admin-page-body">
   <div class="container"> <!-- Using existing container class for some basic centering/width restriction -->
     <h1 id="heading">Stored Entries</h1>
     

--- a/docs/style.css
+++ b/docs/style.css
@@ -14,6 +14,34 @@ body {
   box-sizing: border-box; /* Ensure padding doesn't add to height */
 }
 
+/* Admin page specific body styles for no-scroll behavior */
+html.admin-scroll-lock,
+body.admin-page-body {
+  overflow: hidden; /* Prevent scrolling on html and body for admin page */
+  height: 100%; /* Ensure body takes full viewport height */
+  /* padding-top/bottom removed for admin-page-body as container will handle it */
+}
+
+body.admin-page-body {
+  display: flex;
+  flex-direction: column;
+  padding-top: 0; /* Override general body padding */
+  padding-bottom: 0; /* Override general body padding */
+  /* min-height: 100vh; is inherited and ensures it fills height */
+}
+
+/* Make container on admin page fill height and manage its own potential overflow */
+body.admin-page-body > .container {
+  flex-grow: 1; /* Allow container to grow and fill available vertical space */
+  display: flex; /* Use flex for children of container */
+  flex-direction: column; /* Stack children vertically */
+  overflow-y: auto; /* Allow vertical scroll for container content if it exceeds its bounds */
+  min-height: 0; /* Important for flex children that need to scroll */
+  padding-top: 1rem; /* Restore some padding */
+  padding-bottom: 1rem; /* Restore some padding */
+}
+
+
 /* Specific styles for the main email form page body */
 .form-page-body {
   display: flex;
@@ -43,8 +71,10 @@ body {
 
 /* New wrapper for table scrolling */
 .table-wrapper {
-  max-height: 70vh; /* Set a max-height, e.g., 70% of viewport height */
+  flex-grow: 1; /* Allow table wrapper to take available space in flex column */
+  flex-shrink: 1; /* Allow table wrapper to shrink if needed */
   overflow-y: auto; /* Add vertical scroll if content exceeds max-height */
+  min-height: 0; /* Crucial for scrollable flex children */
   width: 100%; /* Ensure it takes full width of its parent */
   /* border: 1px solid #ddd; */ /* Removed optional border */
   border-radius: 4px; /* Match table's border-radius */


### PR DESCRIPTION
Implemented changes to CSS and admin page HTML to ensure the main body of the admin page does not scroll.

- Added `admin-page-body` class to `body` and `admin-scroll-lock` class to `html` on `admin.html`.
- Modified `style.css`:
    - `html.admin-scroll-lock` and `body.admin-page-body` now have `overflow: hidden` and `height: 100%`.
    - `body.admin-page-body` is set to `display: flex; flex-direction: column;` to manage its children's layout within the viewport.
    - `body.admin-page-body > .container` is now a flex child (`flex-grow: 1`, `overflow-y: auto`, `min-height: 0`) to fill available vertical space and manage scrolling for its own content (header, buttons, pagination) if necessary.
    - `.table-wrapper` (within the admin page's container) is configured as a flex item (`flex-grow: 1`, `flex-shrink: 1`, `min-height: 0`, `overflow-y: auto`) to adapt its height and handle scrolling for the table data internally.

These changes ensure that if the window shrinks, scrolling is confined to the table area or, in specific overflow scenarios, the admin content container, rather than the entire page body. Styles are scoped to avoid impacting `index.html`.